### PR TITLE
Enable bookme modal via hash

### DIFF
--- a/src/components/common/Init.vue
+++ b/src/components/common/Init.vue
@@ -83,13 +83,23 @@ onMounted(() => {
   }
 
   /* CONTACT FORM */
-  const contactButtons = document.querySelectorAll("[href='#contact']");
+  const contactButtons = document.querySelectorAll("[href='#contact'], [href='#bookme']");
   contactButtons.forEach((el) => {
     el.addEventListener("click", (e) => {
       e.preventDefault();
       showContact.set(true);
     });
   });
+
+  const checkHash = () => {
+    const hash = window.location.hash.toLowerCase();
+    if (hash === "#contact" || hash === "#bookme") {
+      showContact.set(true);
+    }
+  };
+
+  checkHash();
+  window.addEventListener("hashchange", checkHash);
 });
 /* CREDITS, PLEASE LEAVE THIS IN PLACE */
 watch(width, (val) => {


### PR DESCRIPTION
## Summary
- trigger the contact dialog using `#bookme`
- react to `#contact` and `#bookme` URL hashes on page load or hashchange

## Testing
- `npm run build` *(fails: invalid json response due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_684c3d8c78288324b65a5e3d9037f217